### PR TITLE
board examples

### DIFF
--- a/src/templates/BoardCard/BoardCard.md
+++ b/src/templates/BoardCard/BoardCard.md
@@ -1,3 +1,5 @@
+### Usage
+
 #### Basic Usage
 
 ```jsx
@@ -16,6 +18,48 @@
         ]
       }
     ])
+  }}
+/>
+```
+
+#### Archived card
+
+```jsx
+<BoardCard
+  block
+  card={{
+    id: "ck354foyadlhe08901ue22g07",
+    content: "",
+    type: "Card",
+    archived: true,
+    x: 480,
+    y: 516,
+    z: 4,
+    width: 300,
+    height: 960,
+    __typename: "Card"
+  }}
+/>
+```
+
+#### Youtube content
+
+```jsx
+<BoardCard
+  block
+  card={{
+    content:
+      '[{"id":675776893448,"name":"type","value":[{"name":"default","children":[{"text":"Lumberjocks Video"}]}]},{"id":2719519280,"name":"yt","value":{"link":"https://www.youtube.com/embed/2JJCXXQqAIk"}},{"id":861852389263,"name":"type","value":[{"name":"default","children":[{}]}]},{"id":242572017073,"name":"link","value":{"url":"https://www.lumberjocks.com/projects/181330","base":"www.lumberjocks.com","image":"http://lumberjocks.com/assets/pictures/projects/903266-97x65.jpg","title":"Mobile Base For A Dutch Tool Chest - by CarterR @ LumberJocks.com ~ woodworking community"}}]'
+  }}
+/>
+```
+
+```jsx
+<BoardCard
+  block
+  card={{
+    content:
+      '[{"id":1213425038528,"name":"type","value":[{"name":"default","children":[{"text":"Chris Schwarz Ideas and Writeup","larger":true}]},{"name":"default","children":[{"text":"Chis Schwarz brought attention to this style of Tool Chest. He has a few writeups on it and blog posts so hes definately a good place to start."}]},{"name":"default","children":[{"text":"Chris Schwarz plans and sketchup"}]}]},{"id":722590329122,"name":"link","value":{"url":"https://www.popularwoodworking.com/woodworking-blogs/dutch-tool-chest-lower-storage-unit/","base":"www.popularwoodworking.com","image":"https://s26462.pcdn.co/wp-content/uploads/Dutch-Chest-With-Lower-Case-e1402947709808.jpg","title":"Dutch Tool Chest with a Lower Storage Unit | Popular Woodworking Magazine"}},{"id":189761849362,"name":"link","value":{"url":"https://blog.lostartpress.com/2012/12/23/lets-go-dutch-tool-chest/\\n","base":"blog.lostartpress.com\\n","image":"https://lostartpress.files.wordpress.com/2012/12/dutch_bench_planes_img_5256.jpg","title":"Let’s Go Dutch (Tool Chest) | Lost Art Press"}},{"id":474640913276,"name":"link","value":{"url":"https://lostartpress.files.wordpress.com/2013/01/dutch_open_img_4536.jpg\\n","base":"lostartpress.files.wordpress.com\\n","title":""}},{"id":1256103301600,"name":"link","value":{"url":"https://blog.lostartpress.com/2013/01/11/a-quick-tour-of-the-dutch-tool-chest/","base":"blog.lostartpress.com","image":"https://lostartpress.files.wordpress.com/2013/01/dutch_covered_img_4538.jpg?w=229","title":"A Quick Tour of the Dutch Tool Chest | Lost Art Press"}}]'
   }}
 />
 ```

--- a/src/templates/BoardCard/BoardCard.md
+++ b/src/templates/BoardCard/BoardCard.md
@@ -42,6 +42,38 @@
 />
 ```
 
+#### Broken Card
+
+```jsx
+<BoardCard
+  card={{
+    content: JSON.stringify([
+      {
+        id: 861852389263,
+        name: "type",
+        value: [{ name: "default", children: [{}] }]
+      }
+    ])
+  }}
+/>
+```
+
+#### Fixed - Broken Card
+
+````jsx
+<BoardCard
+  card={{
+    content: JSON.stringify([
+      {
+        id: 861852389263,
+        name: "type",
+        value: [{ name: "default", children: [{ text: "" }] }]
+      }
+    ])
+  }}
+/>
+``
+
 #### Youtube content
 
 ```jsx
@@ -52,7 +84,7 @@
       '[{"id":675776893448,"name":"type","value":[{"name":"default","children":[{"text":"Lumberjocks Video"}]}]},{"id":2719519280,"name":"yt","value":{"link":"https://www.youtube.com/embed/2JJCXXQqAIk"}},{"id":861852389263,"name":"type","value":[{"name":"default","children":[{}]}]},{"id":242572017073,"name":"link","value":{"url":"https://www.lumberjocks.com/projects/181330","base":"www.lumberjocks.com","image":"http://lumberjocks.com/assets/pictures/projects/903266-97x65.jpg","title":"Mobile Base For A Dutch Tool Chest - by CarterR @ LumberJocks.com ~ woodworking community"}}]'
   }}
 />
-```
+````
 
 ```jsx
 <BoardCard

--- a/src/views/Board/Board.md
+++ b/src/views/Board/Board.md
@@ -4,6 +4,80 @@
 <Board>Board</Board>
 ```
 
+```jsx
+<Board
+  id="ck2s5qc1v7u6h0890vmktiwrm"
+  name="Ideas"
+  description="New Board for helping to organize and visualize ideas"
+  icon="board-icon"
+  archived={false}
+  cards={[
+    {
+      id: "ck2s5t0817u860890sr3816kk",
+      content:
+        '[{"id":1213425038528,"name":"type","value":[{"name":"default","children":[{"text":"Chris Schwarz Ideas and Writeup","larger":true}]},{"name":"default","children":[{"text":"Chis Schwarz brought attention to this style of Tool Chest. He has a few writeups on it and blog posts so hes definately a good place to start."}]},{"name":"default","children":[{"text":"Chris Schwarz plans and sketchup"}]}]},{"id":722590329122,"name":"link","value":{"url":"https://www.popularwoodworking.com/woodworking-blogs/dutch-tool-chest-lower-storage-unit/","base":"www.popularwoodworking.com","image":"https://s26462.pcdn.co/wp-content/uploads/Dutch-Chest-With-Lower-Case-e1402947709808.jpg","title":"Dutch Tool Chest with a Lower Storage Unit | Popular Woodworking Magazine"}},{"id":189761849362,"name":"link","value":{"url":"https://blog.lostartpress.com/2012/12/23/lets-go-dutch-tool-chest/\\n","base":"blog.lostartpress.com\\n","image":"https://lostartpress.files.wordpress.com/2012/12/dutch_bench_planes_img_5256.jpg","title":"Let’s Go Dutch (Tool Chest) | Lost Art Press"}},{"id":474640913276,"name":"link","value":{"url":"https://lostartpress.files.wordpress.com/2013/01/dutch_open_img_4536.jpg\\n","base":"lostartpress.files.wordpress.com\\n","title":""}},{"id":1256103301600,"name":"link","value":{"url":"https://blog.lostartpress.com/2013/01/11/a-quick-tour-of-the-dutch-tool-chest/","base":"blog.lostartpress.com","image":"https://lostartpress.files.wordpress.com/2013/01/dutch_covered_img_4538.jpg?w=229","title":"A Quick Tour of the Dutch Tool Chest | Lost Art Press"}}]',
+      type: "Card",
+      archived: false,
+      x: 24,
+      y: 12,
+      z: 5,
+      width: 408,
+      height: 684,
+      __typename: "Card"
+    },
+    {
+      id: "ck2z3y7zuaxbk0890rq3fha13",
+      content:
+        '[{"id":675776893448,"name":"type","value":[{"name":"default","children":[{"text":"Lumberjocks Video"}]}]},{"id":2719519280,"name":"yt","value":{"link":"https://www.youtube.com/embed/2JJCXXQqAIk"}},{"id":861852389263,"name":"type","value":[{"name":"default","children":[{}]}]},{"id":242572017073,"name":"link","value":{"url":"https://www.lumberjocks.com/projects/181330","base":"www.lumberjocks.com","image":"http://lumberjocks.com/assets/pictures/projects/903266-97x65.jpg","title":"Mobile Base For A Dutch Tool Chest - by CarterR @ LumberJocks.com ~ woodworking community"}}]',
+      type: "Card",
+      archived: false,
+      x: 24,
+      y: 720,
+      z: 5,
+      width: 504,
+      height: 480,
+      __typename: "Card"
+    },
+    {
+      id: "ck30cu0xxbhl00890dp0mi6s8",
+      content: "",
+      type: "Card",
+      archived: true,
+      x: 1080,
+      y: 132,
+      z: 2,
+      width: 225,
+      height: 100,
+      __typename: "Card"
+    },
+    {
+      id: "ck354foyadlhe08901ue22g07",
+      content: "",
+      type: "Card",
+      archived: true,
+      x: 480,
+      y: 516,
+      z: 4,
+      width: 300,
+      height: 960,
+      __typename: "Card"
+    },
+    {
+      id: "ck3kcl5hbkbku0890fj4m4yt4",
+      content: "",
+      type: "Card",
+      archived: true,
+      x: 936,
+      y: 603,
+      z: 3,
+      width: 225,
+      height: 100,
+      __typename: "Card"
+    }
+  ]}
+/>
+```
+
 Source:
 
 ```js { "file": "./Board.js" }


### PR DESCRIPTION
When using the yarn start/stylistguide implementtation use the Examples of BoardCard to see what was causing some boards to get messed up in display.

I have identified it to be an empty object that is part of an array of children off the default type. In the database I found [{}] and changed them to [{text:""}]. this Seems to work appropriately. From what i could tell this was limited to only 13 cards and all of them were created by you or I. so thats cool

- :memo: (Boards) Adding examples with YouTube links
- Demonstrating board card broken press component.
