### PR TITLE
(Helpers) FormatTime

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "rootDir": "src"
   },
   "dependencies": {
+    "moment": "^2.28.0",
     "pressdk": ">=1.0.0",
     "yup": "^0.28.5"
   }

--- a/src/helpers/formatTime/formatTime.js
+++ b/src/helpers/formatTime/formatTime.js
@@ -1,51 +1,25 @@
-const smallMonths = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug"];
-const months = [
-  "January",
-  "Febuary",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August"
-];
+import moment from "moment";
 
+/**
+ * Implements Moment.js for formatting dates
+ * https://momentjs.com/docs/#/displaying/fromnow/
+ *
+ * @param {{time:Date}} param0 input parameters
+ */
 const formatTime = ({
   time = "",
   fullDate = false,
   withTime = false,
-  sinceDate,
   ago = false
 }) => {
-  const toFormat = new Date(Date.parse(time));
-
   if (fullDate) {
-    let returnString = "";
-    returnString += `${
-      months[toFormat.getMonth()]
-    } ${toFormat.getDate()}, ${toFormat.getFullYear()}`;
+    let format = "LL";
     if (withTime) {
-      returnString += ` ${toFormat.getHours()}:${toFormat.getMinutes()}`;
+      format += "L";
     }
-    return returnString;
+    return moment(time).format(format);
   }
-  const today = sinceDate || new Date();
-  const timeSince = today.getTime() - toFormat.getTime();
-  // Not the same year
-  if (toFormat.getFullYear !== today.getFullYear)
-    return `${
-      smallMonths[toFormat.getMonth()]
-    } ${toFormat.getDate()}, ${toFormat.getFullYear()}`;
-  // Greater than 1 day ago (24hr * 60m * 60s * 1000ms)
-  if (timeSince >= 24 * 60 * 60 * 1000)
-    return `${smallMonths[toFormat.getMonth()]} ${toFormat.getDate()}`;
-  // Greater than 1 hr ago (60m * 60s * 1000ms)
-  if (timeSince >= 60 * 60 * 1000)
-    return `${Math.floor(timeSince / (60 * 60 * 1000))}hr`;
-  // Greater than 1 m ago (60s * 1000ms)
-  if (timeSince >= 60 * 1000) return `${Math.floor(timeSince / (60 * 1000))}m`;
-  // Else
-  return "just now";
+  return moment(time).fromNow(!ago);
 };
 
 export default formatTime;

--- a/src/helpers/formatTime/formatTime.test.js
+++ b/src/helpers/formatTime/formatTime.test.js
@@ -4,52 +4,13 @@ describe("Time ago tests", () => {
   test("less than 1m ago", () => {
     expect(
       formatTime({
-        time: "2020-04-06T18:19:00.000Z",
-        sinceDate: new Date(Date.parse("2020-04-06T18:19:59.000Z"))
+        time: new Date() - 1
       })
-    ).toStrictEqual("just now");
+    ).toStrictEqual("a few seconds ago");
   });
-  test("exactly 10m ago", () => {
-    expect(
-      formatTime({
-        time: "2020-04-06T18:19:00.000Z",
-        sinceDate: new Date(Date.parse("2020-04-06T18:29:00.000Z"))
-      })
-    ).toStrictEqual("10m");
-  });
-  test("exactly 1hr ago", () => {
-    expect(
-      formatTime({
-        time: "2020-04-06T18:19:00.000Z",
-        sinceDate: new Date(Date.parse("2020-04-06T19:19:00.000Z"))
-      })
-    ).toStrictEqual("1hr");
-  });
-  test("exactly 6hr ago", () => {
-    expect(
-      formatTime({
-        time: "2020-04-06T18:19:00.000Z",
-        sinceDate: new Date(Date.parse("2020-04-07T00:19:00.000Z"))
-      })
-    ).toStrictEqual("6hr");
-  });
-  test("a little over 6hr ago", () => {
-    expect(
-      formatTime({
-        time: "2020-04-06T18:19:00.000Z",
-        sinceDate: new Date(Date.parse("2020-04-07T00:24:00.000Z"))
-      })
-    ).toStrictEqual("6hr");
-  });
-  test("exactly 1d ago", () => {
-    expect(
-      formatTime({
-        time: "2020-04-06T18:19:00.000Z",
-        sinceDate: new Date(Date.parse("2020-04-07T18:19:00.000Z"))
-      })
-    ).toStrictEqual("Apr 6");
-  });
+});
 
+describe("additional format testing", () => {
   test("full date", () => {
     expect(
       formatTime({
@@ -65,6 +26,6 @@ describe("Time ago tests", () => {
         fullDate: true,
         withTime: true
       })
-    ).toStrictEqual("April 6, 2020 14:19");
+    ).toStrictEqual("April 6, 2020 2:19 PM");
   });
 });


### PR DESCRIPTION
Fixing bug where undefined is happening on dates older than 24 hours ago past the month of august. Minor oversight not completing filling out the rest of the months. Went ahead and brought in moment.js to handle the formatting of relative time as well as locale formatting of dates.


- :heavy_plus_sign: (package.json) adding momentjs dependency
- :globe_with_meridians: (helpers) format time to use moment js for locales


This should resolve https://github.com/lumastic/lumastic-ui/issues/30